### PR TITLE
Removed Sold Cow Toast

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -1,7 +1,6 @@
 import React, {useState} from "react";
 import { Container, CardGroup, Button } from "react-bootstrap";
 import { useParams } from "react-router-dom";
-// import { toast } from "react-toastify";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsOverview from "main/components/Commons/CommonsOverview";

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 import { Container, CardGroup, Button } from "react-bootstrap";
 import { useParams } from "react-router-dom";
-import { toast } from "react-toastify";
+// import { toast } from "react-toastify";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsOverview from "main/components/Commons/CommonsOverview";

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -90,7 +90,7 @@ export default function PlayPage() {
 
 
   const onSuccessSell = () => {
-    toast(`Cow sold!`);
+    
   }
 
   // Stryker disable all 

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -94,7 +94,6 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(2));
 
-        expect(mockToast).toBeCalledWith("Cow sold!");
     });
 
     test("Make sure that both the Announcements and Welcome Farmer components show up", async () => {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I have removed the toast message and the associated toast tests when a cow is sold. This features improves clarity for users by removing distracting toasts like "cow sold" when the change is clearly visible in the cows owned value. 
## Gif (Optional)
![No Toast PR ](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/55556296/3dd24542-496a-473a-bb16-817e880e9f27)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->

Deployed at
1. Clone this repo and checkout yv-no-purchase-toast.
2. run `mvn spring-boot:run`
3. In another terminal, execute `cd /frontend; npm install; npm start`
4. Create a commons, join the commons and go the playpage.
5. This buying and sellling cows

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #3 
