### PR TITLE
Harold ux improvements to leaderboard page 2

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -58,10 +58,10 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8,
-            "cowsBought": 8,
-            "cowsSold": 8,
-            "cowDeaths": 8
+            "numOfCows": 12,
+            "cowsBought": 11,
+            "cowsSold": 10,
+            "cowDeaths": 9
         },
         {
             "id":2,

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -1,8 +1,8 @@
 import OurTable from "main/components/OurTable";
-import { hasRole } from "main/utils/currentUser";
+// import { hasRole } from "main/utils/currentUser";
 
 // should take in a players list from a commons
-export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
+export default function LeaderboardTable({ leaderboardUsers }) {
 
     const USD = new Intl.NumberFormat("en-US", {
         style: "currency",

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -1,5 +1,4 @@
 import OurTable from "main/components/OurTable";
-// import { hasRole } from "main/utils/currentUser";
 
 // should take in a players list from a commons
 export default function LeaderboardTable({ leaderboardUsers }) {
@@ -10,10 +9,6 @@ export default function LeaderboardTable({ leaderboardUsers }) {
     });
 
     const columns = [
-        // {
-        //     Header: 'User Id',
-        //     accessor: 'userId', 
-        // },
         {
             Header: 'Farmer',
             accessor: 'username'
@@ -72,19 +67,6 @@ export default function LeaderboardTable({ leaderboardUsers }) {
     ];
 
     const testid = "LeaderboardTable";
-
-    /* Temp filler for admin leaderboard table */
-
-    // const columnsIfAdmin = [
-    //     // {
-    //     //     Header: '(Admin) userCommons Id',
-    //     //     accessor: 'id'
-    //     // },
-    //     ...columns
-
-    // ];
-
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={leaderboardUsers}

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -10,13 +10,13 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
     });
 
     const columns = [
+        // {
+        //     Header: 'User Id',
+        //     accessor: 'userId', 
+        // },
         {
-            Header: 'User Id',
-            accessor: 'userId', 
-        },
-        {
-            Header: 'Username',
-            accessor: 'username', 
+            Header: 'Farmer',
+            accessor: 'username'
         },
         {
             Header: 'Total Wealth',
@@ -32,22 +32,42 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Bought',
-            accessor: 'cowsBought', 
+            accessor: 'cowsBought',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Sold',
             accessor: 'cowsSold', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Deaths',
-            accessor: 'cowDeaths', 
+            accessor: 'cowDeaths',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  }, 
         },
     ];
 
@@ -55,20 +75,20 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
     /* Temp filler for admin leaderboard table */
 
-    const columnsIfAdmin = [
-        {
-            Header: '(Admin) userCommons Id',
-            accessor: 'id'
-        },
-        ...columns
+    // const columnsIfAdmin = [
+    //     // {
+    //     //     Header: '(Admin) userCommons Id',
+    //     //     accessor: 'id'
+    //     // },
+    //     ...columns
 
-    ];
+    // ];
 
-    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={leaderboardUsers}
-        columns={columnsToDisplay}
+        columns={columns}
         testid={testid}
     />;
 

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -55,6 +55,9 @@ export default function LeaderboardPage() {
     <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
         <BasicLayout>
             <div className="pt-2">
+                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button"  style={{ float: "right", marginRight: "442px"}}>
+                    Back
+                </Button>
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
@@ -62,9 +65,7 @@ export default function LeaderboardPage() {
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
                 </div>
-                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" >
-                    Back
-                </Button>
+
         </BasicLayout>
     </div>
   )

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -109,10 +109,6 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getAllByText("10")[0]).toHaveStyle("text-align: right;");
     expect(screen.getAllByText("9")[0]).toHaveStyle("text-align: right;");
 
-    // expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
-
-    // expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
-
 
   });
     

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -59,14 +59,14 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
+    const expectedHeaders = ['Farmer', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
+    const expectedFields = ['username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -79,21 +79,13 @@ describe("LeaderboardTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1,000.00");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1,000.00");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsSold`)).toHaveTextContent("5");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-cowDeaths`)).toHaveTextContent("5");
-
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-numOfCows`)).toHaveTextContent("12");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowHealth`)).toHaveTextContent("93");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("11");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("10");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("9");
   });
 
   test("Total wealth is formatted correctly", () => {
@@ -102,13 +94,25 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
     expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("12")[0]).toHaveStyle("text-align: right;");
+
+    expect(screen.getAllByText("93")[0]).toHaveStyle("text-align: right;");
+
+    expect(screen.getAllByText("11")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("10")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("9")[0]).toHaveStyle("text-align: right;");
+
+    // expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+
+    // expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+
 
   });
     

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -53,15 +53,13 @@ describe("LeaderboardPage tests", () => {
     test("renders without crashing for users", async () => {
         setupUser();
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            "id": 1,
-            "name": "Anika's Commons",
-            "day": 5,
-            "startingDate": "2026-03-05T15:50:10",
-            "startingBalance": 200.50,
-            "totalPlayers": 50,
-            "cowPrice": 15,
-            "milkPrice": 10,
-            "degradationRate": .5,
+            "username": "Anika",
+            "totalWealth": 100.0,
+            "numOfCows": 5,
+            "cowHealth": 100,
+            "cowsBought": 10,
+            "cowsSold": 3,
+            "cowDeaths": 0,
             "showLeaderboard": true,
         });
         axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);
@@ -80,6 +78,7 @@ describe("LeaderboardPage tests", () => {
         const leaderboard_main_div = screen.getByTestId("LeaderboardPage-main-div");
         const leaderboard_back_button = screen.getByTestId("LeaderboardPage-back-button");
         expect(leaderboard_main_div).toHaveAttribute("style","background-size: cover; background-image: url(PlayPageBackground.png);");
+        expect(leaderboard_back_button).toHaveAttribute("style", "float: right; margin-right: 442px;");
         expect(leaderboard_back_button).toBeInTheDocument();
     });
 
@@ -104,15 +103,13 @@ describe("LeaderboardPage tests", () => {
     test("renders leaderboard for users when showLeaderboard = true", async () => {
         setupUser();
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            "id": 1,
-            "name": "Anika's Commons",
-            "day": 5,
-            "startingDate": "2026-03-05T15:50:10",
-            "startingBalance": 200.50,
-            "totalPlayers": 50,
-            "cowPrice": 15,
-            "milkPrice": 10,
-            "degradationRate": .5,
+            "username": "Anika",
+            "totalWealth": 100.0,
+            "numOfCows": 5,
+            "cowHealth": 100,
+            "cowsBought": 10,
+            "cowsSold": 3,
+            "cowDeaths": 0,
             "showLeaderboard": true,
         });
         axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);
@@ -133,15 +130,13 @@ describe("LeaderboardPage tests", () => {
     test("renders leaderboard error message for users when showLeaderboard = false", async () => {
         setupUser();
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            "id": 1,
-            "name": "Anika's Commons",
-            "day": 5,
-            "startingDate": "2026-03-05T15:50:10",
-            "startingBalance": 200.50,
-            "totalPlayers": 50,
-            "cowPrice": 15,
-            "milkPrice": 10,
-            "degradationRate": .5,
+            "username": "Anika",
+            "totalWealth": 100.0,
+            "numOfCows": 5,
+            "cowHealth": 100,
+            "cowsBought": 10,
+            "cowsSold": 3,
+            "cowDeaths": 0,
             "showLeaderboard": false,
         });
         const queryClient = new QueryClient();
@@ -158,15 +153,13 @@ describe("LeaderboardPage tests", () => {
     test("renders leaderboard for Admin users when showLeaderboard = false", async () => {
         setupAdmin();
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            "id": 1,
-            "name": "Anika's Commons",
-            "day": 5,
-            "startingDate": "2026-03-05T15:50:10",
-            "startingBalance": 200.50,
-            "totalPlayers": 50,
-            "cowPrice": 15,
-            "milkPrice": 10,
-            "degradationRate": .5,
+            "username": "Anika",
+            "totalWealth": 100.0,
+            "numOfCows": 5,
+            "cowHealth": 100,
+            "cowsBought": 10,
+            "cowsSold": 3,
+            "cowDeaths": 0,
             "showLeaderboard": false,
         });
         axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the UX improvements to the leaderboard page were implemented. The "back" button is moved to the top right, the columns titled "userCommons Id" and "User Id" were removed, the column "username" was changed to "Farmer", and all the numerical fields were right justified.

## Before
![image](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/72893084/61eacaa4-f00f-4c20-8e94-78f84b7018a2)

## After
![image](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/72893084/0c31510b-66fb-4577-bffa-69c79f69ca24)


Closes #2 
