### PR TITLE
lli - Added UI changes and tests for Instructor Report Page

### DIFF
--- a/frontend/src/main/components/Reports/ReportHeaderTable.js
+++ b/frontend/src/main/components/Reports/ReportHeaderTable.js
@@ -1,4 +1,5 @@
 import OurTable from "main/components/OurTable";
+import { formatter } from "./ReportLineTable";
 
 // should take in a players list from a commons
 export default function ReportHeaderTable({ report  }) {
@@ -6,14 +7,26 @@ export default function ReportHeaderTable({ report  }) {
         {
             Header: 'Cow Price',
             accessor: 'cowPrice', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+            },
         },
         {
             Header: 'Milk Price',
             accessor: 'milkPrice',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+            },
         },
         {
             Header: 'Start Bal',
             accessor: 'startingBalance',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{formatter.format(props.value)}</div>)
+            },
         },
         {
             Header: 'Start Date',
@@ -29,10 +42,18 @@ export default function ReportHeaderTable({ report  }) {
         {
             Header: 'Capacity',
             accessor: 'carryingCapacity',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Degrad Rate',
             accessor: 'degradationRate',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'BelowCap',

--- a/frontend/src/main/components/Reports/ReportLineTable.js
+++ b/frontend/src/main/components/Reports/ReportLineTable.js
@@ -2,6 +2,15 @@ import OurTable from "main/components/OurTable";
 
 // should take in a players list from a commons
 export default function ReportLineTable({ reportLines }) {
+    const formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      
+        // These options are needed to round to whole numbers if that's what you want.
+        //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
+        //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
+      });
+
     const columns = [
         {
             Header: 'userId',
@@ -14,30 +23,58 @@ export default function ReportLineTable({ reportLines }) {
         {
             Header: 'Total Wealth',
             accessor: 'totalWealth',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{formatter.format(props.value)}</div>)
+                  },
         },
         {
             Header: 'Num Cows',
             accessor: 'numOfCows', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Avg Cow Health',
             accessor: 'avgCowHealth',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Bought',
             accessor: 'cowsBought',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Sold',
             accessor: 'cowsSold',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Deaths',
             accessor: 'cowDeaths',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Create Date',
             accessor: 'createDate',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
     ];
 

--- a/frontend/src/main/components/Reports/ReportLineTable.js
+++ b/frontend/src/main/components/Reports/ReportLineTable.js
@@ -1,16 +1,12 @@
 import OurTable from "main/components/OurTable";
 
+export const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+
 // should take in a players list from a commons
 export default function ReportLineTable({ reportLines }) {
-    const formatter = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-      
-        // These options are needed to round to whole numbers if that's what you want.
-        //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
-        //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
-      });
-
     const columns = [
         {
             Header: 'userId',

--- a/frontend/src/main/components/Reports/ReportTable.js
+++ b/frontend/src/main/components/Reports/ReportTable.js
@@ -25,6 +25,10 @@ export default function ReportTable({ reports, storybook = false, buttons=true }
         {
             Header: 'commonsId',
             accessor: 'commonsId',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+            },
         },
         {
             Header: 'Name',
@@ -37,10 +41,18 @@ export default function ReportTable({ reports, storybook = false, buttons=true }
         {
             Header: 'Num Users',
             accessor: 'numUsers',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+            },
         },
         {
             Header: 'Num Cows',
             accessor: 'numCows',
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+            },
         },
     ];
 

--- a/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportHeaderTable.test.js
@@ -36,15 +36,30 @@ describe("ReportHeaderTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowPrice`)).toHaveTextContent("100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-milkPrice`)).toHaveTextContent("5");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingBalance`)).toHaveTextContent("10000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-startingBalance`)).toHaveTextContent("$10,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-startingDate`)).toHaveTextContent(/^2023-08-06$/);
     expect(screen.getByTestId(`${testId}-cell-row-0-col-showLeaderboard`)).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-carryingCapacity`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-degradationRate`)).toHaveTextContent("0.1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-belowCapacityHealthUpdateStrategy`)).toHaveTextContent("Constant");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-aboveCapacityHealthUpdateStrategy`)).toHaveTextContent("Linear");
-   
   });
 
+  test("Has all numeric values right-justified", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportHeaderTable report={reportFixtures.threeReports[1]}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expect(screen.getAllByText("$10,000.00")[0]).toHaveStyle("text-align: right;")
+    expect(screen.getAllByText("100")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("5")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("10")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("0.1")[0]).toHaveStyle("text-align: right;");
+  })
 });
 

--- a/frontend/src/tests/components/Reports/ReportLineTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportLineTable.test.js
@@ -36,7 +36,7 @@ describe("ReportLineTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("Phill Conrad");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("9745");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$9,745.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-numOfCows`)).toHaveTextContent("3");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`)).toHaveTextContent("100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("3");
@@ -44,6 +44,13 @@ describe("ReportLineTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("0");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-createDate`)).toHaveTextContent("2023-08-07T01:12:54.767+00:00");
 
+    expect(screen.getAllByText("$9,745.00")[0]).toHaveStyle("text-align: right;")
+    expect(screen.getAllByText("3")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("100")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("3")[1]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("0")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("0")[1]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("2023-08-07T01:12:54.767+00:00")[0]).toHaveStyle("text-align: right;");
   });
 
 });

--- a/frontend/src/tests/components/Reports/ReportLineTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportLineTable.test.js
@@ -43,6 +43,17 @@ describe("ReportLineTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("0");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("0");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-createDate`)).toHaveTextContent("2023-08-07T01:12:54.767+00:00");
+  });
+
+  test("Has numeric values right-justified", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportLineTable reportLines={reportLineFixtures.twoReportLines}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
 
     expect(screen.getAllByText("$9,745.00")[0]).toHaveStyle("text-align: right;")
     expect(screen.getAllByText("3")[0]).toHaveStyle("text-align: right;");
@@ -52,6 +63,5 @@ describe("ReportLineTable tests", () => {
     expect(screen.getAllByText("0")[1]).toHaveStyle("text-align: right;");
     expect(screen.getAllByText("2023-08-07T01:12:54.767+00:00")[0]).toHaveStyle("text-align: right;");
   });
-
 });
 

--- a/frontend/src/tests/components/Reports/ReportTable.test.js
+++ b/frontend/src/tests/components/Reports/ReportTable.test.js
@@ -108,5 +108,20 @@ describe("ReportTable tests", () => {
 
   });
 
+  test("Has all numeric values right-justified", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportTable reports={reportFixtures.threeReports} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expect(screen.getAllByText("1")[2]).toHaveStyle("text-align: right;")
+    expect(screen.getAllByText("1")[3]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("3")[0]).toHaveStyle("text-align: right;");  
+  });
+
 });
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I have made changes to the Instructor Report Page UI so that the values for fields like Num Cows, Cows bought, etc, are right-justified and the Total Wealth field is now formatted as currency.

## Screenshots
### Before
<img width="838" alt="Screenshot 2023-11-20 at 2 45 56 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/b49d3f03-6ddc-4d49-8bc1-ddae581b228f">
<img width="705" alt="Screenshot 2023-11-20 at 5 29 38 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/ee3b080c-001c-4bf8-905d-5dfa3fc2de1c">

### After
<img width="949" alt="Screenshot 2023-11-20 at 5 29 42 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/3dc4525e-92dc-497a-a093-0d651b1bf2c7">
<img width="1188" alt="Screenshot 2023-11-20 at 5 32 23 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/1505bfa8-fc0a-40fa-9cca-3cb4a922ffcc">


## Validation
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch and run the project.
3. Login for admin access and create/join a commons.
4. Create an instructor report for the common you've joined from the manage jobs page.
5. Check that the numbers are right-justified and that total wealth is formatted as a currency.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #14
