### PR TITLE
Refactor CommonList component with a default UI

### DIFF
--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -3,6 +3,8 @@ import CommonsCard from "./CommonsCard";
 import { Card, Container, Row, Col } from "react-bootstrap";
 
 const CommonsList = (props) => {
+    const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
+
     return (
         <Card
             style={
@@ -21,21 +23,32 @@ const CommonsList = (props) => {
             >
                 {props.title}
             </Card.Title>
+            {props.commonList.length > 0 ? 
+            <React.Fragment>
+                <Card.Subtitle>
+                    <Container>
+                        <Row>
+                            <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col>
+                            <Col data-testid="commonsList-subtitle-name" sx={4}>Common's Name</Col>
+                            <Col sm={4}></Col>
+                        </Row>
+                    </Container>
+                </Card.Subtitle>
+                {
+                    props.commonList.map(
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
+                    )
+                }
+            </React.Fragment> 
+            : 
             <Card.Subtitle>
                 <Container>
-                    <Row>
-                        <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col>
-                        <Col data-testid="commonsList-subtitle-name" sx={4}>Common's Name</Col>
-                        <Col sm={4}></Col>
+                    <Row style={{justifyContent: "center"}} data-testid="commonsList-default-message">
+                        There are currently no commons to {defaultMessage}
                     </Row>
                 </Container>
             </Card.Subtitle>
-            {
-                props.commonList &&
-                props.commonList.map(
-                    (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
-                )
-            }
+        }
         </Card>
     );
 };

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -29,7 +29,7 @@ const AdminCreateCommonsPage = () => {
     const mutation = useBackendMutation(
         objectToAxiosParams,
         { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching draft
+        // Stryker disable next-line all : hard to set up test for caching
         ["/api/commons/all"]
     );
     // Stryker restore all

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -29,7 +29,7 @@ const AdminCreateCommonsPage = () => {
     const mutation = useBackendMutation(
         objectToAxiosParams,
         { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
+        // Stryker disable next-line all : hard to set up test for caching draft
         ["/api/commons/all"]
     );
     // Stryker restore all

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -89,4 +89,42 @@ describe("CommonsList tests", () => {
             i++;
         })
     });
+
+    test("renders default join UI when there are no commons", () => {
+        render(
+            <CommonsList commonList={[]} buttonText = {"Join"} title="Join A New Commons"/>
+        );
+
+        const title = screen.getByTestId("commonsList-title");
+        expect(title).toBeInTheDocument();
+        expect(typeof(title.textContent)).toBe('string');
+        expect(title.textContent).toEqual('Join A New Commons');
+
+        const subtitle_name = screen.getByTestId("commonsList-default-message");
+        expect(subtitle_name).toBeInTheDocument();
+        expect(typeof(subtitle_name.textContent)).toBe('string');
+        expect(subtitle_name.textContent).toEqual("There are currently no commons to join");
+        expect(subtitle_name).toHaveStyle("justify-content: center;");
+
+        expect(() => screen.getByTestId("commonsList-subtitle-name")).toThrow('Unable to find an element');
+    });
+
+    test("renders default visit UI when there are no commons", () => {
+        render(
+            <CommonsList commonList={[]} buttonText = {"Visit"} title="Visit A Commons"/>
+        );
+
+        const title = screen.getByTestId("commonsList-title");
+        expect(title).toBeInTheDocument();
+        expect(typeof(title.textContent)).toBe('string');
+        expect(title.textContent).toEqual('Visit A Commons');
+
+        const subtitle_name = screen.getByTestId("commonsList-default-message");
+        expect(subtitle_name).toBeInTheDocument();
+        expect(typeof(subtitle_name.textContent)).toBe('string');
+        expect(subtitle_name.textContent).toEqual("There are currently no commons to visit");
+        expect(subtitle_name).toHaveStyle("justify-content: center;")
+
+        expect(() => screen.getByTestId("commonsList-subtitle-name")).toThrow('Unable to find an element');
+    });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, when the common list component in home page is empty, I will show a default UI and when the common list component is not empty, I will the list the component as it is.

## Screenshots (Optional)
### Before

<img width="1440" alt="Screenshot 2023-11-28 at 9 39 03 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/e2ec0c07-ab74-4705-ac12-4a73546ec5ad">

### After

<img width="1440" alt="Screenshot 2023-11-28 at 9 38 37 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/41d48024-1cde-41f1-bd29-4da4fe03dc57">

<img width="1439" alt="Screenshot 2023-11-28 at 9 38 52 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/86935334/541c9a3b-ab7a-41c0-bba9-5b91bcae6bc2">

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #10
