### PR TITLE
Changed Icons for Chat Toggle Button 

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -124,14 +124,14 @@ export default function PlayPage() {
   };
 
   const chatButtonStyle = {
-    width: '40px',
-    height: '40px',
-    borderRadius: '50%',
+    width: '60px',
+    height: '60px',
+    borderRadius: '25%',
     backgroundColor: 'lightblue',
     color: 'black',
     position: 'fixed',
-    bottom: '20px',
-    right: '20px',
+    bottom: '30px',
+    right: '30px',
   };
 
   const chatContainerStyle = {
@@ -139,6 +139,12 @@ export default function PlayPage() {
     position: 'fixed',
     bottom: '100px',
     right: '20px',
+  };
+
+  const emojiStyle = {
+    fontFamily: 'Arial, sans-serif', 
+    fontSize: '30px', 
+
   };
 
   return (
@@ -160,7 +166,7 @@ export default function PlayPage() {
       <div style={chatContainerStyle} data-testid="playpage-chat-div">
         {!!isChatOpen && <ChatPanel commonsId={commonsId}/>}
         <Button style={chatButtonStyle} onClick={toggleChatWindow} data-testid="playpage-chat-toggle">
-          {!!isChatOpen ? '▼' : '▲'}
+          {!!isChatOpen ? <span style={emojiStyle}>❌</span> : <span style={emojiStyle}>💬</span>}
         </Button>
       </div>
     </div>

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -166,7 +166,7 @@ export default function PlayPage() {
       <div style={chatContainerStyle} data-testid="playpage-chat-div">
         {!!isChatOpen && <ChatPanel commonsId={commonsId}/>}
         <Button style={chatButtonStyle} onClick={toggleChatWindow} data-testid="playpage-chat-toggle">
-          {!!isChatOpen ? <span style={emojiStyle}>❌</span> : <span style={emojiStyle}>💬</span>}
+          {!!isChatOpen ? <span style={emojiStyle} data-testid="close-icon">❌</span> : <span style={emojiStyle} data-testid="message-icon">💬</span>}
         </Button>
       </div>
     </div>

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -175,13 +175,19 @@ describe("PlayPage tests", () => {
         const chatButton = screen.getByTestId("playpage-chat-toggle");
         const chatContainer = screen.getByTestId("playpage-chat-div");
 
+        
         expect(chatButton).toHaveTextContent('💬');
-
+        const messageIcon = screen.getByTestId("message-icon");
+        expect(messageIcon).toHaveStyle('font-family: Arial, sans-serif;');
+        expect(messageIcon).toHaveStyle('font-size: 30px;');
         // Click the chat toggle button to open the ChatPanel
         fireEvent.click(chatButton);
 
         await waitFor(() => {
             expect(chatButton).toHaveTextContent('❌');
+            const closeIcon = screen.getByTestId("close-icon");
+            expect(closeIcon).toHaveStyle('font-family: Arial, sans-serif;');
+            expect(closeIcon).toHaveStyle('font-size: 30px;');
         });
 
         // Check styles for the chat button

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -175,25 +175,25 @@ describe("PlayPage tests", () => {
         const chatButton = screen.getByTestId("playpage-chat-toggle");
         const chatContainer = screen.getByTestId("playpage-chat-div");
 
-        expect(chatButton).toHaveTextContent('▲');
+        expect(chatButton).toHaveTextContent('💬');
 
         // Click the chat toggle button to open the ChatPanel
         fireEvent.click(chatButton);
 
         await waitFor(() => {
-            expect(chatButton).toHaveTextContent('▼');
+            expect(chatButton).toHaveTextContent('❌');
         });
 
         // Check styles for the chat button
         expect(chatButton).toHaveStyle(`
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
+            width: 60px;
+            height: 60px;
+            border-radius: 25%;
             background-color: lightblue;
             color: black;
             position: fixed;
-            bottom: 20px;
-            right: 20px;
+            bottom: 30px;
+            right: 30px;
         `);
 
         // Check styles for the chat container

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -185,10 +185,10 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => {
             expect(chatButton).toHaveTextContent('❌');
-            const closeIcon = screen.getByTestId("close-icon");
-            expect(closeIcon).toHaveStyle('font-family: Arial, sans-serif;');
-            expect(closeIcon).toHaveStyle('font-size: 30px;');
         });
+        const closeIcon = screen.getByTestId("close-icon");
+        expect(closeIcon).toHaveStyle('font-family: Arial, sans-serif;');
+        expect(closeIcon).toHaveStyle('font-size: 30px;');
 
         // Check styles for the chat button
         expect(chatButton).toHaveStyle(`


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I changed the icons for open and close chat button on playpage(for users and admin). I have replaced the icons '▼'  and '▲' with '❌' and '💬' respectively. 

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="74" alt="image" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/55556296/06e618dc-926b-40ba-ac91-da1d91d558fb">
<img width="99" alt="image" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-1/assets/55556296/025b0dd6-0f08-4e56-95be-07e18fc51b5c">


## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #13 
