### PR TITLE
set default vals common fields for backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -15,6 +15,7 @@ import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -44,7 +45,48 @@ public class CommonsController extends ApiController {
     @Autowired
     CommonsPlusBuilderService commonsPlusBuilderService;
 
+    @Value("${app.commons.default.startingBalance}")
+    private double defaultStartingBalance;
 
+    @Value("${app.commons.default.cowPrice}")
+    private double defaultCowPrice;
+
+    @Value("${app.commons.default.milkPrice}")
+    private double defaultMilkPrice;
+
+    @Value("${app.commons.default.degradationRate}")
+    private double defaultDegradationRate;
+
+    @Value("${app.commons.default.carryingCapacity}")
+    private int defaultCarryingCapacity;
+
+    @Value("${app.commons.default.capacityPerUser}")
+    private int defaultCapacityPerUser;
+
+    @Value("${app.commons.default.aboveCapacityHealthUpdateStrategy}")
+    private String defaultAboveCapacityHealthUpdateStrategy;
+
+    @Value("${app.commons.default.belowCapacityHealthUpdateStrategy}")
+    private String defaultBelowCapacityHealthUpdateStrategy;
+
+    @Operation(summary = "Get default common values")
+    @GetMapping("/defaults")
+    public ResponseEntity<Commons> getDefaultCommons() throws JsonProcessingException {
+        log.info("getDefaultCommons()...");
+
+        Commons defaultCommons = Commons.builder()
+                .startingBalance(defaultStartingBalance)
+                .cowPrice(defaultCowPrice)
+                .milkPrice(defaultMilkPrice)
+                .degradationRate(defaultDegradationRate)
+                .carryingCapacity(defaultCarryingCapacity)
+                .capacityPerUser(defaultCapacityPerUser)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(defaultAboveCapacityHealthUpdateStrategy))
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(defaultBelowCapacityHealthUpdateStrategy))
+                .build();
+
+        return ResponseEntity.ok().body(defaultCommons);
+    }
 
     @Operation(summary = "Get a list of all commons")
     @GetMapping("/all")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,12 @@ app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
 
+app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:10000.0}}
+app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:100.0}}
+app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:1.0}}
+app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.001}}
+app.commons.default.carryingCapacity=${HAPPYCOWS_CARRYING_CAPACITY:${env.HAPPYCOWS_CARRYING_CAPACITY:100}}	
+app.commons.default.capacityPerUser=${HAPPYCOWS_CAPACITY_PER_USER:${env.HAPPYCOWS_CAPACITY_PER_USER:50}}
+app.commons.default.aboveCapacityHealthUpdateStrategy=${HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:Linear}}
+app.commons.default.belowCapacityHealthUpdateStrategy=${HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:Constant}}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -62,7 +62,6 @@ public class CommonsControllerTests extends ControllerTestCase {
     @WithMockUser(roles = {"ADMIN"})
     @Test
     public void getDefaultCommonsValuesTest() throws Exception {
-        // Set up your expected default values
         Map<String, Object> expectedDefaults = Map.of(
                 "id", 0,
                 "name", "null",
@@ -74,23 +73,18 @@ public class CommonsControllerTests extends ControllerTestCase {
                 "capacityPerUser", 50,
                 "aboveCapacityHealthUpdateStrategy", "Linear",
                 "belowCapacityHealthUpdateStrategy", "Constant"
-                // "showLeaderboard", false
         );
 
         MvcResult response = mockMvc
                 .perform(get("/api/commons/defaults").with(csrf()))
                 .andExpect(status().isOk())
-                // .andExpect(jsonPath("$.name").value("Default Commons"))
-                // .andExpect(jsonPath("$.showLeaderboard").value(false))
                 .andReturn();
 
         Map<String, Object> actualDefaults = objectMapper.readValue(
                 response.getResponse().getContentAsString(),
                 new TypeReference<Map<String, Object>>() {});
 
-        // Compare the actual and expected default values
         assertEquals(expectedDefaults.get("id"), actualDefaults.get("id"));
-        // assertEquals(expectedDefaults.get("name"), actualDefaults.get("name")); // Adjusted assertion
         assertEquals(expectedDefaults.get("cowPrice"), actualDefaults.get("cowPrice"));
         assertEquals(expectedDefaults.get("milkPrice"), actualDefaults.get("milkPrice"));
         assertEquals(expectedDefaults.get("startingBalance"), actualDefaults.get("startingBalance"));
@@ -99,7 +93,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         assertEquals(expectedDefaults.get("capacityPerUser"), actualDefaults.get("capacityPerUser"));
         assertEquals(expectedDefaults.get("aboveCapacityHealthUpdateStrategy"), actualDefaults.get("aboveCapacityHealthUpdateStrategy"));
         assertEquals(expectedDefaults.get("belowCapacityHealthUpdateStrategy"), actualDefaults.get("belowCapacityHealthUpdateStrategy"));
-
     }
 
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -61,6 +61,50 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = {"ADMIN"})
     @Test
+    public void getDefaultCommonsValuesTest() throws Exception {
+        // Set up your expected default values
+        Map<String, Object> expectedDefaults = Map.of(
+                "id", 0,
+                "name", "null",
+                "cowPrice", 100.0,
+                "milkPrice", 1.0,
+                "startingBalance", 10000.0,
+                "degradationRate", 0.001,
+                "carryingCapacity", 100,
+                "capacityPerUser", 50,
+                "aboveCapacityHealthUpdateStrategy", "Linear",
+                "belowCapacityHealthUpdateStrategy", "Constant"
+                // "showLeaderboard", false
+        );
+
+        MvcResult response = mockMvc
+                .perform(get("/api/commons/defaults").with(csrf()))
+                .andExpect(status().isOk())
+                // .andExpect(jsonPath("$.name").value("Default Commons"))
+                // .andExpect(jsonPath("$.showLeaderboard").value(false))
+                .andReturn();
+
+        Map<String, Object> actualDefaults = objectMapper.readValue(
+                response.getResponse().getContentAsString(),
+                new TypeReference<Map<String, Object>>() {});
+
+        // Compare the actual and expected default values
+        assertEquals(expectedDefaults.get("id"), actualDefaults.get("id"));
+        // assertEquals(expectedDefaults.get("name"), actualDefaults.get("name")); // Adjusted assertion
+        assertEquals(expectedDefaults.get("cowPrice"), actualDefaults.get("cowPrice"));
+        assertEquals(expectedDefaults.get("milkPrice"), actualDefaults.get("milkPrice"));
+        assertEquals(expectedDefaults.get("startingBalance"), actualDefaults.get("startingBalance"));
+        assertEquals(expectedDefaults.get("degradationRate"), actualDefaults.get("degradationRate"));
+        assertEquals(expectedDefaults.get("carryingCapacity"), actualDefaults.get("carryingCapacity"));
+        assertEquals(expectedDefaults.get("capacityPerUser"), actualDefaults.get("capacityPerUser"));
+        assertEquals(expectedDefaults.get("aboveCapacityHealthUpdateStrategy"), actualDefaults.get("aboveCapacityHealthUpdateStrategy"));
+        assertEquals(expectedDefaults.get("belowCapacityHealthUpdateStrategy"), actualDefaults.get("belowCapacityHealthUpdateStrategy"));
+
+    }
+
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
     public void createCommonsTest() throws Exception {
         LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the commons variables are set from env variables (for default case)

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![Generic placeholder image](https://picsum.photos/640/480)

## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
- This method might not be the best way to do things. What do you think?
- The way this is implemented is the best I can think of. Is it acceptable?
- Where should these things go? I put them here, but it feels out of place.

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the beginning/part of (insert feature).
- We can extend this to add (something beyond current functions).
- This can make things easier to (insert project).

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
This is the first half of an issue for 10 points, so this won't close the issue
